### PR TITLE
replaced result alert with prompt

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -60,7 +60,7 @@ var getEmailWithURL = function (url) {
     //**crunchbase or team page search by url for founders names
     Parse.Cloud.run('getFoundersEmail', {url: url}, {
       success: function(result) {
-        alert(result);
+        prompt("Copy to clipboard: Ctrl+C, Enter", result);
       },
       error: function(error) {
         console.log('failure');


### PR DESCRIPTION
Instead of alerting the results (which can't be selected by the user to copy) ![alert](https://cloud.githubusercontent.com/assets/5891442/6320902/a3121d92-ba9f-11e4-8427-b437bf252647.png)

The results are entered in a prompt that the user can easily copy and close.
![prompt](https://cloud.githubusercontent.com/assets/5891442/6320908/c3e046e8-ba9f-11e4-8807-091781cdca86.png)
